### PR TITLE
feat: restore unknown MODULE_2 values

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,16 +43,10 @@ jobs:
             -   name: Add Redis to PATH
                 run: echo "$GITHUB_WORKSPACE/redis/bin" >> $GITHUB_PATH
 
-            -   name: Cache Tair Modules
-                id: cache-tair
-                if: contains('5.0, 6.0, 7.0, 8.0', matrix.redis-version)
-                uses: actions/cache@v5
-                with:
-                    path: tair-modules
-                    key: tair-modules-${{ runner.os }}-v1
-
+            # TairHash builds with -march=native; a cached .so from another
+            # runner's CPU can crash redis-server, so always build locally.
             -   name: Build Tair Modules
-                if: contains('5.0, 6.0, 7.0, 8.0', matrix.redis-version) && steps.cache-tair.outputs.cache-hit != 'true'
+                if: contains('5.0, 6.0, 7.0, 8.0', matrix.redis-version)
                 run: |
                     mkdir -p tair-modules
                     for repo in TairString TairHash TairZset; do

--- a/internal/rdb/types/module2.go
+++ b/internal/rdb/types/module2.go
@@ -1,21 +1,78 @@
 package types
 
 import (
+	"bytes"
+	"encoding/binary"
 	"io"
+	"sync"
 
+	"RedisShake/internal/config"
 	"RedisShake/internal/log"
 	"RedisShake/internal/rdb/structure"
+	"RedisShake/internal/utils"
 )
 
 type ModuleObject interface {
 	RedisObject
 }
 
+type UnknownModuleObject struct {
+	key        string
+	moduleName string
+	rd         io.Reader
+	cmdC       chan RedisCmd
+	value      *bytes.Buffer
+}
+
+var unknownModuleNames sync.Map
+
+func (o *UnknownModuleObject) LoadFromBuffer(rd io.Reader, key string, typeByte byte) {
+	o.key = key
+	o.rd = io.TeeReader(rd, o.value)
+	o.cmdC = make(chan RedisCmd)
+	if _, loaded := unknownModuleNames.LoadOrStore(o.moduleName, struct{}{}); !loaded {
+		log.Warnf("unknown module_name=[%s]: using RESTORE; the value cannot be split into commands", o.moduleName)
+	}
+}
+
+func (o *UnknownModuleObject) Rewrite() <-chan RedisCmd {
+	go func() {
+		defer close(o.cmdC)
+		rd := o.rd
+		for opcode := structure.ReadLength(rd); opcode != rdbModuleOpcodeEOF; opcode = structure.ReadLength(rd) {
+			switch opcode {
+			case rdbModuleOpcodeSINT, rdbModuleOpcodeUINT:
+				_ = structure.ReadLength(rd)
+			case rdbModuleOpcodeFLOAT:
+				_ = structure.ReadUint32(rd) // Module FLOAT is binary float32.
+			case rdbModuleOpcodeDOUBLE:
+				_ = structure.ReadDouble(rd)
+			case rdbModuleOpcodeSTRING:
+				_ = structure.ReadString(rd)
+			default:
+				log.Panicf("unknown module opcode: key=[%s], module_name=[%s], opcode=[%d]", o.key, o.moduleName, opcode)
+			}
+		}
+		// value already includes the type and module id; add version and CRC64.
+		dumpSize := uint64(o.value.Len()) + 2 + 8
+		maxBulkLen := config.Opt.Advanced.TargetRedisProtoMaxBulkLen
+		if dumpSize > maxBulkLen {
+			log.Panicf("unknown module requires RESTORE and cannot be split into commands: key=[%s], module_name=[%s], dump size=[%d] exceeds target_redis_proto_max_bulk_len=[%d]", o.key, o.moduleName, dumpSize, maxBulkLen)
+		}
+		_ = binary.Write(o.value, binary.LittleEndian, uint16(6))
+		_ = binary.Write(o.value, binary.LittleEndian, utils.CalcCRC64(o.value.Bytes()))
+		o.cmdC <- RedisCmd{"RESTORE", o.key, "0", o.value.String()}
+	}()
+	return o.cmdC
+}
+
 func PareseModuleType(rd io.Reader, key string, typeByte byte) ModuleObject {
 	if typeByte == rdbTypeModule {
 		log.Panicf("module type with version 1 is not supported, key=[%s]", key)
 	}
-	moduleId := structure.ReadLength(rd)
+	// Preserve the original module id encoding for unknown module RESTORE.
+	value := bytes.NewBuffer([]byte{typeByte})
+	moduleId := structure.ReadLength(io.TeeReader(rd, value))
 	moduleName := ModuleTypeNameByID(moduleId)
 	switch moduleName {
 	case "exstrtype":
@@ -36,9 +93,8 @@ func PareseModuleType(rd io.Reader, key string, typeByte byte) ModuleObject {
 		o.LoadFromBuffer(rd, key, typeByte)
 		return o
 	default:
-		log.Panicf("unsupported module type: %s", moduleName)
-		return nil
-
+		o := &UnknownModuleObject{moduleName: moduleName, value: value}
+		o.LoadFromBuffer(rd, key, typeByte)
+		return o
 	}
-
 }


### PR DESCRIPTION
Unknown `MODULE_2` values can now be migrated through RESTORE using their original encoded payload. The module implementation follows the existing `LoadFromBuffer()` / `Rewrite()` contract: `Rewrite()` reads the fields, preserves the original encoding and returns a RESTORE command. The common RDB and scan readers are unchanged.

The module rejects values whose complete DUMP exceeds `target_redis_proto_max_bulk_len`, including a zero limit, with the key, module name, size and limit in the error. Known module behavior and scan's direct DUMP/RESTORE path are preserved.

CI builds Tair modules in each job because TairHash uses `-march=native`; sharing cached modules between runner CPUs can crash Redis during startup.

Validation: `go build ./...` passed locally with Go 1.26.0. All nine Redis 2.8–8.0 and Valkey 8.0/9.0 CI jobs passed in [run 34576717493](https://github.com/tair-opensource/RedisShake/actions/runs/34576717493); the CLA check also passed.
