### PR TITLE
feat(sync_reader): partial_sync mode, seed from an external snapshot plus PSYNC CONTINUE

### DIFF
--- a/docs/src/en/reader/sync_reader.md
+++ b/docs/src/en/reader/sync_reader.md
@@ -24,6 +24,8 @@ password = ""              # keep empty if no authentication is required
 tls = false
 sync_rdb = true # set to false if you don't want to sync rdb
 sync_aof = true # set to false if you don't want to sync aof
+partial_sync = false # set to true to skip the full sync and stream from the source's current offset
+rdb_file_path = ""   # with partial_sync: snapshot taken after connecting, loaded before the stream is replayed
 ```
 
 * `cluster`: Whether the source is a cluster
@@ -35,3 +37,5 @@ sync_aof = true # set to false if you don't want to sync aof
 * `tls`: Whether the source has enabled TLS/SSL, no need to configure a certificate because RedisShake does not verify the server certificate
 * `sync_rdb`: Whether to synchronize RDB, when set to false, RedisShake will skip the full synchronization phase
 * `sync_aof`: Whether to synchronize AOF, when set to false, RedisShake will skip the incremental synchronization phase, at which point RedisShake will exit after the full synchronization phase is complete.
+* `partial_sync`: Instead of `PSYNC ? -1`, RedisShake reads `master_replid` and `master_repl_offset` from `INFO replication` and asks for a partial resync from that offset. The source answers `+CONTINUE` and never forks, dumps an RDB or buffers the full-sync delta, which matters on busy sources whose replica output buffer limit cannot be raised (for example ElastiCache under heavy write load). The offset must still be inside the source's `repl-backlog`, so raise `repl-backlog-size` if the source refuses. Requires Redis >= 4.0 / Valkey.
+* `rdb_file_path`: Used with `partial_sync`. RedisShake spools the stream and waits for an RDB file to appear at this path (a `BGSAVE` on a replica, or a managed-service backup, taken **after** RedisShake connected). It loads the file, reads its `repl-id` and `repl-offset` aux fields, and replays the spooled stream from `repl-offset + 1`, so the result equals a normal full sync. Without `rdb_file_path` only the stream from the connect offset is replayed, for targets already seeded to exactly that offset.

--- a/internal/rdb/rdb.go
+++ b/internal/rdb/rdb.go
@@ -44,6 +44,8 @@ const (
 
 type Loader struct {
 	replStreamDbId int // https://github.com/tair-opensource/RedisShake/pull/430#issuecomment-1099014464
+	replId         string
+	replOffset     int64
 
 	nowDBId  int
 	expireMs int64
@@ -112,6 +114,16 @@ func (ld *Loader) ParseRDB(ctx context.Context) int {
 	ld.parseRDBEntry(ctx, rd)
 
 	return ld.replStreamDbId
+}
+
+// ReplId returns the repl-id aux field of the RDB, empty if absent.
+func (ld *Loader) ReplId() string {
+	return ld.replId
+}
+
+// ReplOffset returns the repl-offset aux field of the RDB, 0 if absent.
+func (ld *Loader) ReplOffset() int64 {
+	return ld.replOffset
 }
 
 func (ld *Loader) parseRDBEntry(ctx context.Context, rd *bufio.Reader) {
@@ -183,6 +195,14 @@ func (ld *Loader) parseRDBEntry(ctx context.Context, rd *bufio.Reader) {
 					log.Panicf("%v", err)
 				}
 				log.Debugf("[%s] RDB repl-stream-db: [%s]", ld.name, value)
+			} else if key == "repl-id" {
+				ld.replId = value
+			} else if key == "repl-offset" {
+				var err error
+				ld.replOffset, err = strconv.ParseInt(value, 10, 64)
+				if err != nil {
+					log.Panicf("%v", err)
+				}
 			} else if key == "lua" {
 				e := entry.NewEntry()
 				e.Argv = []string{"script", "load", value}

--- a/internal/reader/sync_standalone_reader.go
+++ b/internal/reader/sync_standalone_reader.go
@@ -39,6 +39,8 @@ type SyncReaderOptions struct {
 	SyncAof       bool                   `mapstructure:"sync_aof" default:"true"`
 	PreferReplica bool                   `mapstructure:"prefer_replica" default:"false"`
 	TryDiskless   bool                   `mapstructure:"try_diskless" default:"false"`
+	PartialSync   bool                   `mapstructure:"partial_sync" default:"false"`
+	RdbFilePath   string                 `mapstructure:"rdb_file_path" default:""`
 	Sentinel      client.SentinelOptions `mapstructure:"sentinel"`
 }
 
@@ -49,6 +51,7 @@ type State string
 const (
 	kHandShake  State = "hand shaking"
 	kWaitBgsave State = "waiting bgsave"
+	kWaitRdb    State = "waiting rdb file"
 	kReceiveRdb State = "receiving rdb"
 	kSyncRdb    State = "syncing rdb"
 	kSyncAof    State = "syncing aof"
@@ -143,6 +146,9 @@ func (r *syncStandaloneReader) supportPSync() bool {
 }
 
 func (r *syncStandaloneReader) StartRead(ctx context.Context) []chan *entry.Entry {
+	if r.opts.PartialSync {
+		return r.StartReadWithPartialSync(ctx)
+	}
 	if r.supportPSync() { // Redis version >= 2.8
 		return r.StartReadWithPSync(ctx)
 	} else { // Redis version < 2.8
@@ -170,12 +176,130 @@ func (r *syncStandaloneReader) StartReadWithPSync(ctx context.Context) []chan *e
 		}
 		if r.opts.SyncAof {
 			r.stat.Status = kSyncAof
-			r.sendAOF(startOffset)
+			r.sendAOF(startOffset, 0)
 		}
 		close(r.ch)
 	}()
 
 	return []chan *entry.Entry{r.ch}
+}
+
+// StartReadWithPartialSync asks the source for a partial resync from its current
+// offset, so the source never forks or buffers a full RDB for us. The stream is
+// spooled while the operator produces a snapshot elsewhere (a replica BGSAVE, a
+// managed-service backup); once that file appears at rdb_file_path it is loaded
+// and the spool is replayed from the snapshot's repl-offset. Without rdb_file_path
+// only the stream from the connect offset is replayed.
+func (r *syncStandaloneReader) StartReadWithPartialSync(ctx context.Context) []chan *entry.Entry {
+	r.ctx = ctx
+	r.ch = make(chan *entry.Entry, 1024)
+	go func() {
+		r.sendReplconfListenPort()
+		replId, offset := r.sourceReplicationOffset()
+		r.sendPartialPSync(replId, offset)
+		startOffset := r.stat.AofReceivedOffset
+		go r.sendReplconfAck()
+		go r.receiveAOF()
+
+		applyFrom := int64(0)
+		if r.opts.RdbFilePath != "" {
+			r.waitForRdbFile(r.opts.RdbFilePath)
+			ld := r.sendRDB(r.opts.RdbFilePath)
+			if ld.ReplId() == "" || ld.ReplOffset() == 0 {
+				log.Panicf("[%s] rdb file has no repl-id/repl-offset aux fields, cannot align it with the stream. path=[%s]", r.stat.Name, r.opts.RdbFilePath)
+			}
+			if ld.ReplId() != replId {
+				log.Panicf("[%s] rdb repl-id [%s] does not match source replid [%s]", r.stat.Name, ld.ReplId(), replId)
+			}
+			if ld.ReplOffset() < startOffset {
+				log.Panicf("[%s] rdb repl-offset [%d] predates the stream start [%d]; take the snapshot after RedisShake is connected", r.stat.Name, ld.ReplOffset(), startOffset)
+			}
+			applyFrom = ld.ReplOffset() + 1
+			log.Infof("[%s] rdb loaded at repl-offset [%d], replaying stream from there", r.stat.Name, ld.ReplOffset())
+		}
+		r.stat.Status = kSyncAof
+		r.sendAOF(startOffset, applyFrom)
+		close(r.ch)
+	}()
+
+	return []chan *entry.Entry{r.ch}
+}
+
+func (r *syncStandaloneReader) sourceReplicationOffset() (string, int64) {
+	reply := r.client.DoWithStringReply("info", "replication")
+	var replId string
+	var offset int64
+	for _, line := range strings.Split(reply, "\n") {
+		line = strings.TrimSpace(line)
+		if v, ok := strings.CutPrefix(line, "master_replid:"); ok {
+			replId = v
+		} else if v, ok := strings.CutPrefix(line, "master_repl_offset:"); ok {
+			var err error
+			offset, err = strconv.ParseInt(v, 10, 64)
+			if err != nil {
+				log.Panicf("[%s] bad master_repl_offset [%s]", r.stat.Name, v)
+			}
+		}
+	}
+	if replId == "" {
+		log.Panicf("[%s] INFO replication has no master_replid", r.stat.Name)
+	}
+	return replId, offset
+}
+
+func (r *syncStandaloneReader) sendPartialPSync(replId string, offset int64) {
+	cmd := "PSYNC"
+	if config.Opt.Advanced.AwsPSync != "" {
+		cmd = config.Opt.Advanced.GetPSyncCommand(r.stat.Address)
+	}
+	r.client.Send(cmd, replId, strconv.FormatInt(offset+1, 10))
+	for {
+		peakByte, err := r.client.Peek()
+		if err != nil {
+			log.Panicf("%v", err)
+		}
+		if peakByte != '\n' {
+			break
+		}
+		_, _ = r.client.ReadByte()
+	}
+	reply := r.client.ReceiveString()
+	if !strings.HasPrefix(reply, "CONTINUE") {
+		log.Panicf("[%s] partial resync refused, reply=[%s]. The offset [%d] is no longer in the source repl-backlog; raise repl-backlog-size on the source and retry", r.stat.Name, reply, offset+1)
+	}
+	r.stat.AofReceivedOffset = offset
+	log.Infof("[%s] partial resync accepted at replid [%s] offset [%d]", r.stat.Name, replId, offset)
+}
+
+func (r *syncStandaloneReader) waitForRdbFile(path string) {
+	r.stat.Status = kWaitRdb
+	log.Infof("[%s] waiting for rdb file at [%s]", r.stat.Name, path)
+	var lastSize int64 = -1
+	for {
+		select {
+		case <-r.ctx.Done():
+			runtime.Goexit()
+		case <-time.After(time.Second):
+		}
+		fi, err := os.Stat(path)
+		if err != nil {
+			continue
+		}
+		if fi.Size() > 0 && fi.Size() == lastSize {
+			return
+		}
+		lastSize = fi.Size()
+	}
+}
+
+// respArrayLen is the wire size of argv as a RESP array of bulk strings, which is
+// the only shape the replication stream uses.
+func respArrayLen(argv []string) int64 {
+	n := int64(1 + len(strconv.Itoa(len(argv))) + 2)
+	for _, a := range argv {
+		n += int64(1 + len(strconv.Itoa(len(a))) + 2 + len(a) + 2)
+	}
+	return n
 }
 
 // StartReadWithSync is only used in Redis version < 2.8
@@ -196,7 +320,7 @@ func (r *syncStandaloneReader) StartReadWithSync(ctx context.Context) []chan *en
 		}
 		if r.opts.SyncAof {
 			r.stat.Status = kSyncAof
-			r.sendAOF(startOffset)
+			r.sendAOF(startOffset, 0)
 		}
 		close(r.ch)
 	}()
@@ -501,7 +625,7 @@ func (r *syncStandaloneReader) receiveAOF() {
 	}
 }
 
-func (r *syncStandaloneReader) sendRDB(rdbFilePath string) {
+func (r *syncStandaloneReader) sendRDB(rdbFilePath string) *rdb.Loader {
 	// start parse rdb
 	log.Debugf("[%s] start sending RDB to target", r.stat.Name)
 	r.stat.Status = kSyncRdb
@@ -514,12 +638,17 @@ func (r *syncStandaloneReader) sendRDB(rdbFilePath string) {
 	// delete file
 	_ = os.Remove(rdbFilePath)
 	log.Debugf("[%s] delete RDB file", r.stat.Name)
+	return rdbLoader
 }
 
-func (r *syncStandaloneReader) sendAOF(offset int64) {
+// sendAOF replays the spooled stream. offset is the replication offset the spool
+// starts after; entries whose first byte is below applyFromOffset are skipped.
+func (r *syncStandaloneReader) sendAOF(offset int64, applyFromOffset int64) {
 	aofReader := rotate.NewAOFReader(r.ctx, r.stat.Name, r.stat.Dir, offset)
 	defer aofReader.Close()
 	protoReader := proto.NewReader(bufio.NewReader(aofReader))
+	nextEntryOffset := offset + 1
+	skipped := 0
 	for {
 		if err := r.ctx.Err(); err != nil {
 			log.Infof("[%s] sendAOF exit", r.stat.Name)
@@ -536,6 +665,16 @@ func (r *syncStandaloneReader) sendAOF(offset int64) {
 
 		argv := client.ArrayString(iArgv, nil)
 		r.stat.AofSentOffset = aofReader.Offset()
+		entryOffset := nextEntryOffset
+		nextEntryOffset += respArrayLen(argv)
+		if entryOffset < applyFromOffset {
+			skipped++
+			continue
+		}
+		if skipped > 0 {
+			log.Infof("[%s] skipped %d entries already contained in the RDB, replay starts at offset %d", r.stat.Name, skipped, entryOffset)
+			skipped = 0
+		}
 		// select
 		if strings.EqualFold(argv[0], "select") {
 			DbId, err := strconv.Atoi(argv[1])

--- a/shake.toml
+++ b/shake.toml
@@ -8,6 +8,8 @@ sync_rdb = true            # Set to false if RDB synchronization is not required
 sync_aof = true            # Set to false if AOF synchronization is not required
 prefer_replica = false     # Set to true to sync from a replica node
 try_diskless = false       # Set to true for diskless sync if the source has repl-diskless-sync=yes
+partial_sync = false       # Set to true to PSYNC from the source's current offset instead of a full sync (no fork on the source)
+rdb_file_path = ""         # With partial_sync, an RDB taken after RedisShake connected; loaded, then the stream replays from its repl-offset
 
 #[scan_reader]
 #cluster = false            # set to true if source is a redis cluster


### PR DESCRIPTION
## Problem

A full sync makes the source fork, dump an RDB and buffer every write for the whole dump in its replica output buffer. On busy sources where that limit cannot be raised (ElastiCache marks `client-output-buffer-limit-replica-*` not modifiable) the source closes the link before the RDB finishes, so `sync_reader` can never attach under load. We hit this on an ElastiCache Valkey 7.2 cluster at ~77K writes/s per shard: the link dropped 75 s after PSYNC on every attempt, while the same RDB syncs in 20 s at low load.

## Change

`partial_sync = true` reads `master_replid` and `master_repl_offset` from `INFO replication` and sends `PSYNC <replid> <offset+1>` instead of `PSYNC ? -1`. The source answers `+CONTINUE` and streams its backlog only; it never forks. The stream is spooled to the existing rotating AOF files while the operator produces a snapshot elsewhere (a `BGSAVE` on a replica, a managed-service backup). When that file appears at `rdb_file_path` it is loaded and the spool is replayed from the snapshot's `repl-offset` aux field, which is the replica restart path, so nothing is double-applied. Without `rdb_file_path` the stream from the connect offset is replayed as is.

- `sendAOF` tracks each entry's replication offset from its RESP size so entries already contained in the snapshot are skipped exactly.
- `rdb.Loader` exposes the `repl-id` and `repl-offset` aux fields; the reader refuses a snapshot whose replid differs or whose offset predates the connect offset.
- A refused partial resync (`+FULLRESYNC`) panics with a hint to raise `repl-backlog-size`.

## Testing

- Valkey 7.2.11 locally: primary with a replica, empty target, mixed SET/INCRBY/SETEX/DEL load (~270K writes over the run). Partial resync accepted, 4 MB spooled before the replica `BGSAVE`, snapshot loaded, 101,609 entries skipped, the rest replayed. Target key set, values, TTLs and all INCRBY counters equal the primary.
- ElastiCache Valkey 7.2, cluster mode, 3 shards at ~77K writes/s and 27 MB/s of stream per shard, one process per primary: `+CONTINUE` on all three, `rdb_last_save_time` on the source unchanged (no BGSAVE), 4.5 GiB streamed per shard in 3 minutes with apply lag under 30 KB.

Draft while I finish the snapshot leg on ElastiCache (backup export) and add a test under `tests/`. Feedback on the option names and on whether waiting for the RDB file by size stability is acceptable would be welcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)